### PR TITLE
Remove invalid syntax

### DIFF
--- a/sfz2 basic tests/18 - EG/99 - eg01_pitch (tool generated).sfz
+++ b/sfz2 basic tests/18 - EG/99 - eg01_pitch (tool generated).sfz
@@ -9,7 +9,7 @@ sample=..\..\samples\440.wav
 loopstart=12629 loopend=56728 loopmode=loop_continuous
 ampeg_release=40
 
-/------------------------------------------------------------------------------
+
 eg01_points=10 eg01_loop=3 eg01_loop_shape=002.00000 eg01_sustain=6
 
 eg01_time00=000.00000    eg01_level00=0.00000    eg01_shape00=002.00000
@@ -22,7 +22,7 @@ eg01_time06=001.03750    eg01_level06=0.28000    eg01_shape06=002.00000
 eg01_time07=001.22250    eg01_level07=0.23000    eg01_shape07=002.00000
 eg01_time08=001.58750    eg01_level08=0.80000    eg01_shape08=002.00000
 eg01_time09=002.35000    eg01_level09=0.00000    eg01_shape09=002.00000
-/------------------------------------------------------------------------------
+
 
 
 


### PR DESCRIPTION
When running the sfizz parser on this repo it errored on this file:
```
$ ./sfizz_preprocessor "./sfz2 basic tests/18 - EG/99 - eg01_pitch (tool generated).sfz" --mode=xml
Parse error in "99 - eg01_pitch (tool generated).sfz" at line 12: Expected opcode name.
Parse error in "99 - eg01_pitch (tool generated).sfz" at line 25: Expected opcode name.
```

Removing the invalid syntax fixes the issues and generates:
```
$ ./sfizz_preprocessor "./sfz2 basic tests/18 - EG/99 - eg01_pitch (tool generated).sfz" --mode=xml
<?xml version="1.0"?>
<region>
        <opcode name="sample" value="..\..\samples\440.wav" />
        <opcode name="loopstart" value="12629" />
        <opcode name="loopend" value="56728" />
        <opcode name="loopmode" value="loop_continuous" />
        <opcode name="ampeg_release" value="40" />
        <opcode name="eg01_points" value="10" />
        <opcode name="eg01_loop" value="3" />
        <opcode name="eg01_loop_shape" value="002.00000" />
        <opcode name="eg01_sustain" value="6" />
        <opcode name="eg01_time00" value="000.00000" />
        <opcode name="eg01_level00" value="0.00000" />
        <opcode name="eg01_shape00" value="002.00000" />
        <opcode name="eg01_time01" value="000.20250" />
        <opcode name="eg01_level01" value="0.86000" />
        <opcode name="eg01_shape01" value="002.00000" />
        <opcode name="eg01_time02" value="000.07500" />
        <opcode name="eg01_level02" value="0.15000" />
        <opcode name="eg01_shape02" value="002.00000" />
        <opcode name="eg01_time03" value="000.17000" />
        <opcode name="eg01_level03" value="0.53000" />
        <opcode name="eg01_shape03" value="002.00000" />
        <opcode name="eg01_time04" value="000.76250" />
        <opcode name="eg01_level04" value="0.54000" />
        <opcode name="eg01_shape04" value="002.00000" />
        <opcode name="eg01_time05" value="000.78250" />
        <opcode name="eg01_level05" value="0.78000" />
        <opcode name="eg01_shape05" value="002.00000" />
        <opcode name="eg01_time06" value="001.03750" />
        <opcode name="eg01_level06" value="0.28000" />
        <opcode name="eg01_shape06" value="002.00000" />
        <opcode name="eg01_time07" value="001.22250" />
        <opcode name="eg01_level07" value="0.23000" />
        <opcode name="eg01_shape07" value="002.00000" />
        <opcode name="eg01_time08" value="001.58750" />
        <opcode name="eg01_level08" value="0.80000" />
        <opcode name="eg01_shape08" value="002.00000" />
        <opcode name="eg01_time09" value="002.35000" />
        <opcode name="eg01_level09" value="0.00000" />
        <opcode name="eg01_shape09" value="002.00000" />
        <opcode name="eg01_pitch" value="2400" />
</region>
```

This PR fixes the issue.