### PR TITLE
Instructions how to generate xml and json versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@ Shared as public domain documentation and software test suite
 with authors permissions.
 
 [Cakewalk forum]: http://forum.cakewalk.com/Dimension-Pro-sfz-v2-test-suite-1-m645298.aspx
+
+
+## Generate xml and json versions
+
+Automatically generate `.xml` versions of each `.sfz` file using the sfizz preprocessor tool:
+
+    curl -LO https://github.com/studiorack/sfizz/releases/download/v1.1.1/sfizz-preprocessor-mac.zip
+    unzip sfizz-preprocessor-mac.zip && rm sfizz-preprocessor-mac.zip
+    IFS=$'\n'
+    for file in $(find . -type f -name '*.sfz'); do ./sfizz_preprocessor "$file" --mode=xml > "${file%.*}.xml"; done
+
+Automatically convert `.xml` files to `.json` using the yq tool:
+
+    pip install yq
+    for file in $(find . -type f -name '*.xml'); do cat "$file" | xq . > "${file%.*}.json"; done


### PR DESCRIPTION
When testing a parser you need to test the input `.sfz` file against an "valid" output `.xml` or `.json`.
We can do this using the sfizz parser to generate the xml representation.

The commands included in this PR convert a file such as:
```
<region>
sample=..\..\samples\440.wav loopstart=12629 loopend=56728 loopmode=loop_continuous
amplfo_freq=1 amplfo_depth=6 volume=-10
```

into xml:
```
<?xml version="1.0"?>
<region>
	<opcode name="sample" value="..\..\samples\440.wav" />
	<opcode name="loopstart" value="12629" />
	<opcode name="loopend" value="56728" />
	<opcode name="loopmode" value="loop_continuous" />
	<opcode name="amplfo_freq" value="1" />
	<opcode name="amplfo_depth" value="6" />
	<opcode name="volume" value="-10" />
</region>
```

and json:
```
{
  "region": {
    "opcode": [
      {
        "@name": "sample",
        "@value": "..\\..\\samples\\440.wav"
      },
      {
        "@name": "loopstart",
        "@value": "12629"
      },
      {
        "@name": "loopend",
        "@value": "56728"
      },
      {
        "@name": "loopmode",
        "@value": "loop_continuous"
      },
      {
        "@name": "amplfo_freq",
        "@value": "1"
      },
      {
        "@name": "amplfo_depth",
        "@value": "6"
      },
      {
        "@name": "volume",
        "@value": "-10"
      }
    ]
  }
}
```